### PR TITLE
Fixed Azure OpenAI API error which crashed all chatbot conversations

### DIFF
--- a/{{cookiecutter.project_name}}/apps/api/{{cookiecutter.__api_package_name}}/ai/assistants/conversation_assistant.py
+++ b/{{cookiecutter.project_name}}/apps/api/{{cookiecutter.__api_package_name}}/ai/assistants/conversation_assistant.py
@@ -16,7 +16,7 @@ PROMPT_TEMPLATE = PromptTemplate(
     input_variables=["chat_history", "question"],
     template=(
         """The following is a friendly conversation between a user and an AI assistant. The AI assistant is talkative and provides lots of specific details from its context.
-If the assistant does not know the answer to a question, it truthfully says it does not know.
+If the assistant does not know the answer to a question, it does not make up answer and says "I don't know".
 The assistant should format its responses using newlines in a way that is easy to read.
 
 Current conversation:


### PR DESCRIPTION
Azure OpenAIApi was throwing error 

`openai.BadRequestError: Error code: 400 - {'error': {'message': "The response was filtered due to the prompt triggering Azure OpenAI's content management policy. Please modify your prompt and retry. To learn more about our content filtering policies please read our documentation: [https://go.microsoft.com/fwlink/?linkid=2198766"](https://go.microsoft.com/fwlink/?linkid=2198766%22), 'type': None, 'param': 'prompt', 'code': 'content_filter', 'status': 400, 'innererror': {'code': 'ResponsibleAIPolicyViolation', 'content_filter_result': {'hate': {'filtered': False, 'severity': 'safe'}, 'jailbreak': {'filtered': True, 'detected': True}, 'self_harm': {'filtered': False, 'severity': 'safe'}, 'sexual': {'filtered': False, 'severity': 'safe'}, 'violence': {'filtered': False, 'severity': 'safe'}}}}}`

This small change fixes it and AI API works again.