### PR TITLE
refactor: Migrate legacy LLMChain usage to LCEL syntax

### DIFF
--- a/docs/app-api-code-guide.md
+++ b/docs/app-api-code-guide.md
@@ -82,7 +82,7 @@ All the LLM providers are subclasses of the `AbstractLLMProvider` class. The cur
   - `_get_stop_sequence` (optional) - returns the sequence of tokens that will be used by the assistant to determine when to stop the response generation.
   - `_get_llm` - returns the LLM provider that will be used by the assistant to generate the response.
 
-  By default, the `AbstractBasicAssistant` class uses the `LLMChain`. However, if it is not enough for your needs, you can override the `_get_chain` method and return any other Langchain chain that the assistant should use.
+  By default, the `AbstractBasicAssistant` class uses the `Runnable` pipe defined in LangChain Express Language. However, if it is not enough for your needs, you can override the `_get_chain` method and return any other Langchain chain that the assistant should use.
 
   After you have overridden the methods mentioned above, you can add a `generate` method to your assistant, which should call either `self._run_buffered(...)` or `self._run_streamed(...)`  methods depending on whether you want to use the "buffered" or "streamed" approach. Keep in mind that if you use the "streamed" approach, then the LLM returned by the `_get_llm` method should support the streaming mode. For more details see the example implementations of `ConversationAssistantBuffered`, `ConversationAssistantStreamed`, and `SubjectLineAssistant` classes.
 

--- a/{{cookiecutter.project_name}}/apps/api/{{cookiecutter.__api_package_name}}/ai/assistants/abstract_assistant.py
+++ b/{{cookiecutter.project_name}}/apps/api/{{cookiecutter.__api_package_name}}/ai/assistants/abstract_assistant.py
@@ -4,14 +4,12 @@ This module contains the conversational assistant. It is a simple wrapper around
 
 import asyncio
 from abc import ABC, abstractmethod
-from types import MethodType
-from typing import Any, AsyncIterable, Coroutine, Optional
+from typing import Any, AsyncIterable, cast, Coroutine
 
 from langchain.callbacks import AsyncIteratorCallbackHandler
-from langchain.callbacks.manager import AsyncCallbackManagerForChainRun
-from langchain.chains.base import Chain
-from langchain.chains.llm import LLMChain
 from langchain.prompts import PromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.runnables import Runnable, RunnableConfig
 
 from ...app.settings import settings
 from ..llms import LLM, llm_provider
@@ -27,48 +25,36 @@ class AbstractAssistant(ABC):
     def _get_llm(self) -> LLM:
         """Get the LLM to use"""
 
-    async def _run_chain_buffered(self, chain: Chain, inputs: dict[str, Any]) -> str:
+    def _runnable_config(self, **kwargs) -> RunnableConfig:
+        """Get the runnable config to use with the chain.invoke or chain.ainvoke methods"""
+        runnable_dict: dict[str, Any] = {"verbose": IS_VERBOSE}
+
+        # Note: by adding kwargs parameters they will be added to the runnable config, overriding any existing parameters.
+        #  That option is used in _run_chain_streamed to add the callbacks parameter.
+        if kwargs:
+            runnable_dict.update(kwargs)
+
+        return cast(RunnableConfig, runnable_dict)
+
+    async def _run_chain_buffered(self, chain: Runnable, inputs: dict[str, Any]) -> str:
         """Generates a buffered response to the given message"""
-        output_key = chain.output_keys[0]
-        output = (await chain.ainvoke(inputs, return_only_outputs=True, include_run_info=False))[output_key]
+        output = await chain.ainvoke(inputs, conf=self._runnable_config())
 
-        return str(output).strip()
+        return output
 
-    async def _run_chain_streamed(self, chain: Chain, inputs: dict[str, Any]) -> AsyncIterable[str]:
+    async def _run_chain_streamed(self, chain: Runnable, inputs: dict[str, Any]) -> AsyncIterable[str]:
         """Generates a streamed response to the given message"""
         if not llm_provider.is_streaming_enabled(self._get_llm()):
             raise NotImplementedError("Streaming is not supported by the LLM model")
 
         callback = AsyncIteratorCallbackHandler()
 
-        async def run_chain() -> dict[str, Any]:
-            # The response chain may be a subchain of the main chain
-            # Usually, if the main chain is a composition of multiple subchains then the response chain will be the last one
-            # For example, in the ConversationRetrievalChain the combine_docs_chain will be the response chain because it is the last chain in the main chain
-            response_chain = self._get_response_chain(chain)
-            # pylint: disable-next=protected-access
-            response_chain_acall = response_chain._acall
-
-            # Override the _acall method of the response chain to add the callback handler to the run manager
-            # Unfotunately, we can't add the callback handler to response_chain.callback because those callbacks are not passed downstream, e.g., to the LLM model
-            async def response_chain_acall_override(
-                _,
-                inputs: dict[str, Any],
-                run_manager: Optional[AsyncCallbackManagerForChainRun] = None,
-            ) -> dict[str, Any]:
-                if run_manager is not None:
-                    run_manager.inheritable_handlers.append(callback)
-                return await response_chain_acall(inputs, run_manager)
-
-            response_chain.__dict__["_acall"] = MethodType(response_chain_acall_override, response_chain)
-
-            try:
-                return await chain.ainvoke(inputs, return_only_outputs=True, include_run_info=False)
-            finally:
-                del response_chain.__dict__["_acall"]
-                callback.done.set()
-
-        task = asyncio.create_task(run_chain())
+        task = asyncio.create_task(
+            chain.ainvoke(
+                inputs,
+                config=self._runnable_config(callbacks=[callback]),
+            )
+        )
         pending = True
 
         async for token in callback.aiter():
@@ -79,21 +65,20 @@ class AbstractAssistant(ABC):
             yield token
 
         outputs = await task
-        output_key = chain.output_keys[0]
 
         # If no response has been streamed, there still may be a generated output
         # for example, if the LLM model is not streamable or if the response has been generated prematurely
         # like in the ConversationRetrievalChain when no documents are found and the response is generated immediately without passing through the LLM model
-        if pending and (output_key in outputs):
-            yield str(outputs[output_key]).strip()
+        if pending and outputs:
+            yield outputs
 
-    def _get_response_chain(self, chain: Chain) -> Chain:
+    def _get_response_chain(self, chain: Runnable) -> Runnable:
         """Get the response chain from the main chain, i.e., the chain that generates the final response for the user"""
         return chain
 
 
 class AbstractBasicAssistant(AbstractAssistant):
-    """Simple assistant that uses the LLMChain class to generate buffered or streamed responses"""
+    """Simple assistant that uses the LangChain Express Language chain to generate buffered or streamed responses"""
 
     def _run_buffered(self, inputs: dict[str, Any]) -> Coroutine[Any, Any, str]:
         return self._run_chain_buffered(self._get_chain(), self._with_stop_sequence(inputs))
@@ -101,14 +86,12 @@ class AbstractBasicAssistant(AbstractAssistant):
     def _run_streamed(self, inputs: dict[str, Any]) -> AsyncIterable[str]:
         return self._run_chain_streamed(self._get_chain(), self._with_stop_sequence(inputs))
 
-    def _get_chain(self) -> Chain:
-        """Creates the chain - by default, it is a simple LLMChain but can be overridden to use a different chain in a subclass"""
-        return LLMChain(
-            llm=self._get_llm(),
-            prompt=self._get_prompt_template(),
-            output_key=OUTPUT_KEY,
-            verbose=IS_VERBOSE,
-        )
+    def _get_chain(self) -> Runnable:
+        """Creates the chain - by default, it is a simple pipe of Runnables but can be overridden to use a different pipe in a subclass"""
+        llm = self._get_llm()
+        prompt = self._get_prompt_template()
+        # StrOutputParser is used to ensure the output is a string
+        return prompt | llm | StrOutputParser()
 
     @abstractmethod
     def _get_prompt_template(self) -> PromptTemplate:

--- a/{{cookiecutter.project_name}}/apps/api/{{cookiecutter.__api_package_name}}/ai/llms/abstract_llm_provider.py
+++ b/{{cookiecutter.project_name}}/apps/api/{{cookiecutter.__api_package_name}}/ai/llms/abstract_llm_provider.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from enum import StrEnum
 from typing import Any, ClassVar
 
-from langchain.base_language import BaseLanguageModel
+from langchain_core.language_models import BaseLanguageModel
 from langchain.callbacks.base import Callbacks
 from langchain.chat_models.base import BaseChatModel
 from langchain.embeddings.base import Embeddings


### PR DESCRIPTION
The deprecated LLMChain has been replaced with the modern LangChain Expression Language (LCEL) chain syntax.

This ensures the codebase uses the current, supported pattern for defining and running LLM applications, 
preparing for the eventual removal of legacy Chain objects (LangChain v0.1.0+).
