### PR TITLE
fix: add missing PromptTemplate import to conversation_assistant template

### DIFF
--- a/{{cookiecutter.project_name}}/apps/api/{{cookiecutter.__api_package_name}}/ai/assistants/conversation_assistant.py
+++ b/{{cookiecutter.project_name}}/apps/api/{{cookiecutter.__api_package_name}}/ai/assistants/conversation_assistant.py
@@ -9,7 +9,7 @@ from typing import Any, AsyncIterable
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.output_parsers import StrOutputParser
-from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder, PromptTemplate
 from langchain_core.runnables import RunnablePassthrough
 
 from ...models import Message, MessageRole


### PR DESCRIPTION
The conversation assistant template used `PromptTemplate` for `PROMPT_TEMPLATE` but
did not import it, causing `NameError` in generated apps.

This change adds `PromptTemplate` to the existing `langchain_core.prompts` import.