### PR TITLE
fix: add missing PromptTemplate import to conversation_assistant template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ## Unreleased
 
+- **fix**: Add missing PromptTemplate import to conversation_assistant template.
+
 ## 2.1.0 - 2025-12-22
 
 - **feat(rag)**: Add full Retrieval-Augmented Generation support and update template. Introduce complete RAG functionality to the chatbot template. Key changes include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   - Once a release is cut, move items from "Unreleased" into a new version section.
   - Group entries with short, action-oriented descriptions (e.g. "feat", "fix", "chore", "docs").
 -->
+## Unreleased
+
+
 
 ## 2.1.1 - 2026-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - Group entries with short, action-oriented descriptions (e.g. "feat", "fix", "chore", "docs").
 -->
 
-## Unreleased
+## 2.1.1 - 2026-02-12
 
 - **fix**: Add missing PromptTemplate import to conversation_assistant template.
 

--- a/{{cookiecutter.project_name}}/apps/api/{{cookiecutter.__api_package_name}}/ai/assistants/conversation_assistant.py
+++ b/{{cookiecutter.project_name}}/apps/api/{{cookiecutter.__api_package_name}}/ai/assistants/conversation_assistant.py
@@ -9,7 +9,7 @@ from typing import Any, AsyncIterable
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.output_parsers import StrOutputParser
-from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder, PromptTemplate
 from langchain_core.runnables import RunnablePassthrough
 
 from ...models import Message, MessageRole


### PR DESCRIPTION
## Summary

The conversation assistant template used `PromptTemplate` for the `PROMPT_TEMPLATE` constant but did not import it, causing `NameError` when generated apps imported the module.

## Changes

- Add `PromptTemplate` to the `langchain_core.prompts` import in `conversation_assistant.py`
- Update CHANGELOG under Unreleased